### PR TITLE
Fix broken Bitcoin validation on iPhone

### DIFF
--- a/explorer/app2/js/app.js
+++ b/explorer/app2/js/app.js
@@ -130,8 +130,8 @@ function setupTransactions() {
 }
 
 function setupWatchTextbox(idSuffix) {
-  $('#txt-watch-' + idSuffix).keyup(function() {
-    var address = $('#txt-watch-' + idSuffix).val();
+  $('#txt-watch-' + idSuffix).on('input', function() {
+    var address = $(this).val();
     var isValid = WAValidator.validate(address, "bitcoin", "prod");
     if (isValid) {
       $('#btn-watch-' + idSuffix).removeAttr('disabled');


### PR DESCRIPTION
IPhone doesn't handle "paste" events the same way as desktop does.
Listening to another event than "keyup" (namely the "input" event)
solves the issue.

Fixes: #36 