### PR TITLE
Configure latest Bitcoin block timestamp

### DIFF
--- a/explorer/app2/js/app.js
+++ b/explorer/app2/js/app.js
@@ -167,7 +167,7 @@ function updateStats() {
     $(this).text(beautifulNumber(currentMetricsResult.average));
   });
   $('.age-date').each(function() {
-    $(this).text(beautifulDate(1555502400000)); //April 17, 12:00:00 UTC
+    $(this).text(beautifulDate(currentMetricsResult.latest));
   });
   $('.next-datetime').each(function() {
     $(this).text(beautifulDateTime(currentMetricsResult.next));

--- a/explorer/app2/js/explorer.js
+++ b/explorer/app2/js/explorer.js
@@ -32,6 +32,7 @@ const MOCK_METRICS = function() {
     peak: Math.floor(Math.random() * 1000000),
     average: Math.floor(Math.random() * 1000000),
     progress: Math.floor(Math.random() * 100),
+    latest: 1561378584000, // 2019-06-24 12:16:24 UTC
     state: DEMO_STATE,
     start: 1550867544,
     stop: 1560867544,
@@ -63,6 +64,7 @@ function getMetrics() {
             peak: json.data.peakTps,
             average: json.data.averageTps,
             progress: percentage,
+            latest: json.meta.progressLatest,
             state: json.meta.testState,
             start: json.meta.testStart,
             stop: json.meta.testStop,

--- a/explorer/service/src/main/java/org/radixdlt/explorer/config/Configuration.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/config/Configuration.java
@@ -20,6 +20,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 public final class Configuration {
     public static final int DEFAULT_TRANSACTIONS_PAGE_SIZE = 50;
+    public static final long DEFAULT_LATEST_TRANSACTION_TIMESTAMP = 0;
     public static final long DEFAULT_METRICS_INTERVAL = SECONDS.toMillis(10);
     public static final long DEFAULT_METRICS_TOTAL = 100;
     public static final long DEFAULT_NODES_INTERVAL = SECONDS.toMillis(30);
@@ -162,7 +163,8 @@ public final class Configuration {
     }
 
     /**
-     * @return The path to the file where any calculated metrics should be dumped.
+     * @return The path to the file where any calculated metrics should
+     * be dumped.
      */
     public synchronized Path getMetricsDumpFilePath() {
         String value = properties.getProperty("metrics.dump");
@@ -179,6 +181,20 @@ public final class Configuration {
         } catch (NumberFormatException e) {
             LOGGER.warn("Couldn't read transactions page size property, falling back to default", e);
             return DEFAULT_TRANSACTIONS_PAGE_SIZE;
+        }
+    }
+
+    /**
+     * @return Return the timestamp of the most recent Bitcoin block in
+     * the dataset.
+     */
+    public synchronized long getLatestTransactionTimestamp() {
+        String value = properties.getProperty("transactions.latest");
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            LOGGER.warn("Couldn't read latest transaction timestamp, falling back to default", e);
+            return DEFAULT_LATEST_TRANSACTION_TIMESTAMP;
         }
     }
 

--- a/explorer/service/src/main/java/org/radixdlt/explorer/metrics/MetricsGetHandler.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/metrics/MetricsGetHandler.java
@@ -39,7 +39,8 @@ public class MetricsGetHandler implements Handler {
                 .addMetaData("testStop", state.getStopTimestamp())
                 .addMetaData("testNext", configuration.getNextTestRunUtc())
                 // TODO: </ugly>
-                .addMetaData("progressMax", configuration.getMetricsTotalTransactions());
+                .addMetaData("progressMax", configuration.getMetricsTotalTransactions())
+                .addMetaData("progressLatest", configuration.getLatestTransactionTimestamp());
 
         long maxAgeConfig = configuration.getMetricsCalculationInterval();
         long maxAge = MILLISECONDS.toSeconds(maxAgeConfig);

--- a/explorer/service/src/main/resources/config.properties
+++ b/explorer/service/src/main/resources/config.properties
@@ -8,6 +8,7 @@ metrics.interval=4000
 metrics.max=427763433
 metrics.dump=/opt/radixdlt/service/data/metrics.csv
 transactions.size=50
+transactions.latest=1561378584000
 universe.shards=17592186044416
 universe.magic=1363935234
 test.dump=/opt/radixdlt/service/data/state.csv

--- a/explorer/service/src/test/java/org/radixdlt/explorer/config/ConfigurationTest.java
+++ b/explorer/service/src/test/java/org/radixdlt/explorer/config/ConfigurationTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.radixdlt.explorer.config.Configuration.DEFAULT_LATEST_TRANSACTION_TIMESTAMP;
 import static org.radixdlt.explorer.config.Configuration.DEFAULT_METRICS_INTERVAL;
 import static org.radixdlt.explorer.config.Configuration.DEFAULT_METRICS_TOTAL;
 import static org.radixdlt.explorer.config.Configuration.DEFAULT_NEXT_TEST;
@@ -111,6 +112,13 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void whe_requesting_existing_latest_transaction_timestamp__correct_value_is_returned() throws IOException {
+        Files.write(CONFIG, "transactions.latest=123".getBytes());
+        Configuration.getInstance().reload();
+        assertThat(Configuration.getInstance().getLatestTransactionTimestamp()).isEqualTo(123);
+    }
+
+    @Test
     public void when_requesting_valid_shards_count__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "universe.shards=2.0E2".getBytes());
         Configuration.getInstance().reload();
@@ -205,6 +213,13 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void when_requesting_invalid_latest_transaction_timestamp__default_value_is_returned() throws IOException {
+        Files.write(CONFIG, "transactions.latest=invalid".getBytes());
+        Configuration.getInstance().reload();
+        assertThat(Configuration.getInstance().getLatestTransactionTimestamp()).isEqualTo(DEFAULT_LATEST_TRANSACTION_TIMESTAMP);
+    }
+
+    @Test
     public void when_requesting_invalid_shards_count__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "universe.shards=invalid".getBytes());
         Configuration.getInstance().reload();
@@ -279,6 +294,13 @@ public class ConfigurationTest {
         Files.write(CONFIG, "".getBytes());
         Configuration.getInstance().reload();
         assertThat(Configuration.getInstance().getTransactionsPageSize()).isEqualTo(DEFAULT_TRANSACTIONS_PAGE_SIZE);
+    }
+
+    @Test
+    public void when_requesting_non_existing_latest_transaction_timestamp__default_value_is_returned() throws IOException {
+        Files.write(CONFIG, "".getBytes());
+        Configuration.getInstance().reload();
+        assertThat(Configuration.getInstance().getLatestTransactionTimestamp()).isEqualTo(DEFAULT_LATEST_TRANSACTION_TIMESTAMP);
     }
 
     @Test


### PR DESCRIPTION
This change offers means of changing a "hard-coded" timestamp of the latest Bitcoin block timestamp in the pumped data set. Note that this isn't (yet) the timestamp of the latest processed Bitcoin block in the Radix 1M TPS ledger.