### PR TITLE
Expect 'config.properties' to be in persistent data path

### DIFF
--- a/explorer/service/src/main/java/org/radixdlt/explorer/Application.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/Application.java
@@ -98,9 +98,10 @@ public class Application {
      * java resources.
      */
     private static void ensureProperties() {
-        if (!Files.exists(Paths.get("config.properties"))) {
+        Path configFilePath = Paths.get(Configuration.CONFIG_FILE);
+        if (!Files.exists(configFilePath)) {
             try (InputStream source = Application.class.getResourceAsStream("/config.properties")) {
-                Files.copy(source, Paths.get("config.properties"));
+                Files.copy(source, configFilePath);
             } catch (IOException e) {
                 throw new UncheckedIOException("Couldn't read configuration properties", e);
             }

--- a/explorer/service/src/main/java/org/radixdlt/explorer/config/Configuration.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/config/Configuration.java
@@ -29,7 +29,7 @@ public final class Configuration {
     public static final int DEFAULT_TEST_RUNNING = 100;
     public static final long DEFAULT_NEXT_TEST = 0L;
     public static final int DEFAULT_UNIVERSE_MAGIC = -849412095;
-    private static final String CONFIG_FILE = "config.properties";
+    public static final String CONFIG_FILE = "/opt/radixdlt/service/data/config.properties";
     private static final Logger LOGGER = LoggerFactory.getLogger("org.radixdlt.explorer");
 
     private final Properties properties;


### PR DESCRIPTION
This means that if there is no configuration file in the persistent
data path, then, the Explorer will extract a default one there. If
there on the other hand already exists a config file there, then,
that file will be used.