### PR TITLE
Isolate data dumping to file

### DIFF
--- a/explorer/service/src/main/java/org/radixdlt/explorer/helper/DumpHelper.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/helper/DumpHelper.java
@@ -15,6 +15,11 @@ import java.util.concurrent.RejectedExecutionException;
 import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
+/**
+ * Offers means of safely dumping data to a file on the filesystem. This
+ * helper class enqueues any dump tasks in a single threaded executor
+ * service and each dump is forcefully synced to the file system.
+ */
 public class DumpHelper {
     private static final Logger LOGGER = LoggerFactory.getLogger("org.radixdlt.explorer");
     private final ExecutorService dumpExecutor;
@@ -56,6 +61,7 @@ public class DumpHelper {
                     fileOutputStream.write(data);
                     fileOutputStream.flush();
                     fileOutputStream.getFD().sync();
+                    fileOutputStream.close();
                     Files.move(tmpFilePath, targetFilePath, ATOMIC_MOVE, REPLACE_EXISTING);
                 } catch (Exception e) {
                     LOGGER.info("Couldn't dump data to file: " + path.toString(), e);

--- a/explorer/service/src/main/java/org/radixdlt/explorer/helper/DumpHelper.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/helper/DumpHelper.java
@@ -40,7 +40,7 @@ public class DumpHelper {
      * @param path The path to the file to dump it in (or null, in which
      *             case nothing is dumped.
      */
-    public synchronized void dumpData(byte[] data, Path path) {
+    public void dumpData(byte[] data, Path path) {
         if (path == null) {
             return;
         }
@@ -74,7 +74,7 @@ public class DumpHelper {
      * @return The last line in the provided file. May be empty
      * if the file was empty or null if something goes wrong.
      */
-    public synchronized String restoreLastDumpedData(Path path) {
+    public String restoreLastDumpedData(Path path) {
         if (path == null) {
             return null;
         }

--- a/explorer/service/src/main/java/org/radixdlt/explorer/helper/DumpHelper.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/helper/DumpHelper.java
@@ -6,7 +6,6 @@ import io.reactivex.schedulers.Schedulers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
@@ -176,8 +175,11 @@ public class DumpHelper {
 
         @Override
         public String call() throws Exception {
-            File file = path.toFile();
-            try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
+            if (!Files.exists(path)) {
+                return "";
+            }
+
+            try (RandomAccessFile randomAccessFile = new RandomAccessFile(path.toFile(), "r")) {
                 long filePointer = randomAccessFile.length();
                 long fileLength = filePointer - 1;
                 StringBuilder sb = new StringBuilder();

--- a/explorer/service/src/main/java/org/radixdlt/explorer/helper/DumpHelper.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/helper/DumpHelper.java
@@ -1,5 +1,8 @@
 package org.radixdlt.explorer.helper;
 
+import io.reactivex.Completable;
+import io.reactivex.Single;
+import io.reactivex.schedulers.Schedulers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -8,14 +11,16 @@ import java.io.FileOutputStream;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Offers means of safely dumping data to a file on the filesystem. This
@@ -25,116 +30,167 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 public class DumpHelper {
     private static final Logger LOGGER = LoggerFactory.getLogger("org.radixdlt.explorer");
     private final ExecutorService dumpExecutor;
+    private final Path dumpFilePath;
 
 
-    public DumpHelper() {
+    public DumpHelper(Path dumpFilePath) {
         this.dumpExecutor = Executors.newSingleThreadExecutor();
+        if (dumpFilePath != null) {
+            this.dumpFilePath = dumpFilePath.toAbsolutePath();
+            this.dumpFilePath.getParent().toFile().mkdirs();
+        } else {
+            this.dumpFilePath = null;
+        }
     }
 
     /**
-     * Shuts down the dump executor, allowing the currently executing
-     * task to finish, but not starting any new tasks.
-     */
-    public void stopDumpExecutor() {
-        dumpExecutor.shutdownNow();
-    }
-
-    /**
-     * Makes an atomic (-ish) dump of the provided data to the provided
-     * path.
+     * Shuts down the dump executor, allowing any submitted tasks to
+     * finish executing within 10 seconds, but not accepting any new
+     * tasks.
      *
-     * @param data The data to dump.
-     * @param path The path to the file to dump it in (or null, in which
-     *             case nothing is dumped.
+     * @return A handle to the shutdown task that the caller can use
+     * to detect when the shutdown has been finished and the success
+     * state of it.
      */
-    public Future<?> dumpData(byte[] data, Path path) {
-        if (path == null) {
-            return CompletableFuture.completedFuture(null);
+    public Completable stop() {
+        return Completable
+                .fromCallable(() -> {
+                    dumpExecutor.shutdown();
+                    dumpExecutor.awaitTermination(10, SECONDS);
+                    return null;
+                })
+                .subscribeOn(Schedulers.io());
+    }
+
+    /**
+     * Submits an atomic dump-to-file task of the provided string.
+     *
+     * @param string The data to dump.
+     * @return A handle to the dump task that the caller can use to detect
+     * when the task has been finished and the success state of it.
+     */
+    public Completable dumpData(final String string) {
+        if (dumpFilePath == null || string == null || string.isEmpty()) {
+            return Completable.complete();
         }
 
         try {
-            return dumpExecutor.submit(() -> {
-                // Ensure parent folder exists
-                Path destination = path.toAbsolutePath();
-                destination.getParent().toFile().mkdirs();
-
-                // TODO: Document the reason we're doing this complicated
-                //       file write procedure.
-                Path tmp = destination.resolveSibling(destination.getFileName() + ".txt");
-                if (Files.exists(destination)) {
-                    try {
-                        Files.move(destination, tmp, ATOMIC_MOVE, REPLACE_EXISTING);
-                    } catch (Exception e) {
-                        LOGGER.warn("Couldn't prepare file to dump to: " + tmp.toString(), e);
-                        return;
-                    }
-                }
-
-                try (FileOutputStream fileOutputStream = new FileOutputStream(tmp.toString(), true)) {
-                    fileOutputStream.write(data);
-                    fileOutputStream.flush();
-                    fileOutputStream.getFD().sync();
-                    fileOutputStream.close();
-                    Files.move(tmp, destination, ATOMIC_MOVE, REPLACE_EXISTING);
-                } catch (Exception e) {
-                    LOGGER.info("Couldn't dump data to file: " + path.toString(), e);
-                }
-            });
+            // Ensure trailing new-line
+            String line = string.endsWith("\n") ? string : (string + "\n");
+            byte[] data = line.getBytes(UTF_8);
+            DumpTask task = new DumpTask(dumpFilePath, data);
+            Future<?> future = dumpExecutor.submit(task);
+            return Completable.fromFuture(future);
         } catch (RejectedExecutionException e) {
-            LOGGER.info("Couldn't enqueue dump data task. Ignoring this," +
-                    " but you should look into it as the dump file may now be broken", e);
-
-            return CompletableFuture.completedFuture(null);
+            LOGGER.info("Couldn't enqueue dump task", e);
+            return Completable.error(e);
         }
     }
 
     /**
-     * Reads the last line from the file at the provided path.
+     * Reads the last line from the dump file.
      *
-     * @param path The path to the file to read from.
-     * @return The last line in the provided file. May be empty
-     * if the file was empty or null if something goes wrong.
+     * @return The last line in the dump file. May be an empty string if
+     * the dump file was empty or no dump file was specified.
      */
-    public String restoreLastDumpedData(Path path) {
-        if (path == null) {
-            return null;
+    public Single<String> restoreData() {
+        if (dumpFilePath == null) {
+            return Single.just("");
         }
 
-        File file = path.toAbsolutePath().toFile();
-        try (RandomAccessFile fileHandler = new RandomAccessFile(file, "r")) {
-            long filePointer = fileHandler.length();
-            long fileLength = filePointer - 1;
-            StringBuilder sb = new StringBuilder();
+        try {
+            RestoreTask task = new RestoreTask(dumpFilePath);
+            Future<String> future = dumpExecutor.submit(task);
+            return Single.fromFuture(future);
+        } catch (RejectedExecutionException e) {
+            LOGGER.info("Couldn't enqueue restore task", e);
+            return Single.error(e);
+        }
+    }
 
-            // Fast-forward past the end of the file
-            // and start reading the bytes from the
-            // end until the first (last) line feed
-            // is encountered.
-            while (--filePointer != -1) {
-                fileHandler.seek(filePointer);
-                int readByte = fileHandler.readByte();
+    /**
+     * Encapsulates the work that needs to be done when dumping data to
+     * the dump file.
+     */
+    private static final class DumpTask implements Callable<Void> {
+        private final Path path;
+        private final byte[] data;
 
-                if (readByte == 0xA) { // 'new line'
-                    if (filePointer == fileLength) {
-                        continue;
-                    }
-                    break;
-                } else if (readByte == 0xD) { // 'carriage return'
-                    if (filePointer == fileLength - 1) {
-                        continue;
-                    }
-                    break;
-                }
+        private DumpTask(Path path, byte[] data) {
+            this.path = path;
+            this.data = data;
+        }
 
-                sb.append((char) readByte);
+        @Override
+        public Void call() throws Exception {
+            // Create a temporary file to work with in isolation.
+            // Make sure we're appending to existing data, not to
+            // an empty file.
+            Path tmp = path.resolveSibling(path.getFileName() + ".tmp");
+            if (Files.exists(path)) {
+                Files.move(path, tmp, ATOMIC_MOVE, REPLACE_EXISTING);
             }
 
-            return sb.reverse().toString();
-        } catch (Exception e) {
-            LOGGER.info("Couldn't restore previously dumped data," +
-                    " falling back to default", e);
+            // Now, append to temporary file and make sure all data
+            // is flushed to the file sink and synchronized with the
+            // file system. Once we're sure all bytes exist on disk,
+            // we're ready to (atomically) update the persisted file.
+            try (FileOutputStream fileOutputStream = new FileOutputStream(tmp.toString(), true)) {
+                fileOutputStream.write(data);
+                fileOutputStream.flush();
+                fileOutputStream.getFD().sync();
+                fileOutputStream.close();
+                Files.move(tmp, path, ATOMIC_MOVE, REPLACE_EXISTING);
+            }
+
             return null;
         }
     }
+
+    /**
+     * Encapsulates the work that needs to be done when restoring data
+     * from the last line in the dump file.
+     */
+    private static final class RestoreTask implements Callable<String> {
+        private final Path path;
+
+        private RestoreTask(Path path) {
+            this.path = path;
+        }
+
+        @Override
+        public String call() throws Exception {
+            File file = path.toFile();
+            try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
+                long filePointer = randomAccessFile.length();
+                long fileLength = filePointer - 1;
+                StringBuilder sb = new StringBuilder();
+
+                // Fast-forward past the end of the file and start reading
+                // the bytes from the end until the first (last) line feed
+                // is encountered.
+                while (--filePointer != -1) {
+                    randomAccessFile.seek(filePointer);
+                    int readByte = randomAccessFile.readByte();
+                    if (readByte == 0xA) { // 'new line'
+                        if (filePointer == fileLength) {
+                            continue;
+                        }
+                        break;
+                    } else if (readByte == 0xD) { // 'carriage return'
+                        if (filePointer == fileLength - 1) {
+                            continue;
+                        }
+                        break;
+                    }
+
+                    sb.append((char) readByte);
+                }
+
+                return sb.reverse().toString();
+            }
+        }
+    }
+
 
 }

--- a/explorer/service/src/main/java/org/radixdlt/explorer/helper/DumpHelper.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/helper/DumpHelper.java
@@ -1,0 +1,119 @@
+package org.radixdlt.explorer.helper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+public class DumpHelper {
+    private static final Logger LOGGER = LoggerFactory.getLogger("org.radixdlt.explorer");
+    private final ExecutorService dumpExecutor;
+
+
+    public DumpHelper() {
+        this.dumpExecutor = Executors.newSingleThreadExecutor();
+    }
+
+    /**
+     * Shuts down the dump executor, allowing the currently executing
+     * task to finish, but not starting any new tasks.
+     */
+    public void stopDumpExecutor() {
+        dumpExecutor.shutdownNow();
+    }
+
+    /**
+     * Makes an atomic (-ish) dump of the provided data to the provided
+     * path.
+     *
+     * @param data The data to dump.
+     * @param path The path to the file to dump it in (or null, in which
+     *             case nothing is dumped.
+     */
+    public synchronized void dumpData(byte[] data, Path path) {
+        if (path == null) {
+            return;
+        }
+
+        try {
+            dumpExecutor.submit(() -> {
+                // Ensure parent folder exists
+                path.toAbsolutePath().getParent().toFile().mkdirs();
+                Path tmpFilePath = path.getParent().resolve("tmp.txt").toAbsolutePath();
+                Path targetFilePath = path.toAbsolutePath();
+
+                try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFilePath.toString())) {
+                    fileOutputStream.write(data);
+                    fileOutputStream.flush();
+                    fileOutputStream.getFD().sync();
+                    Files.move(tmpFilePath, targetFilePath, ATOMIC_MOVE, REPLACE_EXISTING);
+                } catch (Exception e) {
+                    LOGGER.info("Couldn't dump data to file: " + path.toString(), e);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            LOGGER.info("Couldn't enqueue dump data task. Ignoring this," +
+                    " but you should look into it as the dump file may now be broken", e);
+        }
+    }
+
+    /**
+     * Reads the last line from the file at the provided path.
+     *
+     * @param path The path to the file to read from.
+     * @return The last line in the provided file. May be empty
+     * if the file was empty or null if something goes wrong.
+     */
+    public synchronized String restoreLastDumpedData(Path path) {
+        if (path == null) {
+            return null;
+        }
+
+        File file = path.toAbsolutePath().toFile();
+        try (RandomAccessFile fileHandler = new RandomAccessFile(file, "r")) {
+            long filePointer = fileHandler.length();
+            long fileLength = filePointer - 1;
+            StringBuilder sb = new StringBuilder();
+
+            // Fast-forward past the end of the file
+            // and start reading the bytes from the
+            // end until the first (last) line feed
+            // is encountered.
+            while (--filePointer != -1) {
+                fileHandler.seek(filePointer);
+                int readByte = fileHandler.readByte();
+
+                if (readByte == 0xA) { // 'new line'
+                    if (filePointer == fileLength) {
+                        continue;
+                    }
+                    break;
+                } else if (readByte == 0xD) { // 'carriage return'
+                    if (filePointer == fileLength - 1) {
+                        continue;
+                    }
+                    break;
+                }
+
+                sb.append((char) readByte);
+            }
+
+            return sb.reverse().toString();
+        } catch (Exception e) {
+            LOGGER.info("Couldn't restore previously dumped data," +
+                    " falling back to default", e);
+            return null;
+        }
+    }
+
+}

--- a/explorer/service/src/main/java/org/radixdlt/explorer/metrics/MetricsProvider.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/metrics/MetricsProvider.java
@@ -11,7 +11,6 @@ import org.radixdlt.explorer.system.model.SystemInfo;
 import java.nio.file.Path;
 import java.util.Map;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.radixdlt.explorer.system.TestState.STARTED;
 import static org.radixdlt.explorer.system.TestState.UNKNOWN;
 
@@ -47,7 +46,7 @@ class MetricsProvider {
         this.subject = PublishSubject.create();
         this.disposables = new CompositeDisposable();
         this.calculationLock = new Object();
-        this.dumpHelper = new DumpHelper();
+        this.dumpHelper = new DumpHelper(metricsDumpPath);
         this.maxShards = maxShards;
         this.isStarted = false;
         this.peakTps = 0L;
@@ -103,7 +102,7 @@ class MetricsProvider {
             isStarted = false;
             disposables.clear();
             subject.onComplete();
-            dumpHelper.stopDumpExecutor();
+            dumpHelper.stop();
         }
     }
 
@@ -182,8 +181,7 @@ class MetricsProvider {
      */
     private void resetDumpFile() {
         if (metricsDumpPath != null) {
-            byte[] data = Metrics.DATA_HEADLINE.getBytes(UTF_8);
-            dumpHelper.dumpData(data, metricsDumpPath);
+            dumpHelper.dumpData(Metrics.DATA_HEADLINE);
         }
     }
 
@@ -192,9 +190,7 @@ class MetricsProvider {
      */
     private void dumpCurrentMetrics() {
         if (metricsDumpPath != null) {
-            String line = calculatedMetrics.toString();
-            byte[] data = line.getBytes(UTF_8);
-            dumpHelper.dumpData(data, metricsDumpPath);
+            dumpHelper.dumpData(calculatedMetrics.toString());
         }
     }
 
@@ -204,7 +200,7 @@ class MetricsProvider {
      */
     private void restoreMetrics() {
         if (metricsDumpPath != null) {
-            String lastLine = dumpHelper.restoreLastDumpedData(metricsDumpPath);
+            String lastLine = dumpHelper.restoreData().blockingGet();
             calculatedMetrics = Metrics.fromCSV(lastLine);
         }
     }

--- a/explorer/service/src/main/java/org/radixdlt/explorer/metrics/MetricsProvider.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/metrics/MetricsProvider.java
@@ -7,8 +7,6 @@ import org.radixdlt.explorer.helper.DumpHelper;
 import org.radixdlt.explorer.metrics.model.Metrics;
 import org.radixdlt.explorer.system.TestState;
 import org.radixdlt.explorer.system.model.SystemInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.Map;
@@ -21,8 +19,6 @@ import static org.radixdlt.explorer.system.TestState.UNKNOWN;
  * Enables means of getting calculated Radix network throughput metrics.
  */
 class MetricsProvider {
-    private static final Logger LOGGER = LoggerFactory.getLogger("org.radixdlt.explorer");
-
     private final PublishSubject<Metrics> subject;
     private final CompositeDisposable disposables;
     private final Object calculationLock;
@@ -107,6 +103,7 @@ class MetricsProvider {
             isStarted = false;
             disposables.clear();
             subject.onComplete();
+            dumpHelper.stopDumpExecutor();
         }
     }
 

--- a/explorer/service/src/main/java/org/radixdlt/explorer/system/TestState.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/system/TestState.java
@@ -33,6 +33,7 @@ public enum TestState {
      */
     UNKNOWN;
 
+    public static final String DATA_HEADLINE = "Timestamp,State,Start,Stop\n";
     private static final Logger LOGGER = LoggerFactory.getLogger("org.radixdlt.explorer");
 
     private long start = 0L;
@@ -43,15 +44,15 @@ public enum TestState {
             return UNKNOWN;
         }
 
-        String[] components = line.split(",", 4);
-        if (components.length < 3) {
+        String[] components = line.split(",", 5);
+        if (components.length < 4) {
             return UNKNOWN;
         }
 
         try {
-            TestState state = TestState.valueOf(components[0]);
-            state.start = Long.valueOf(components[1]);
-            state.stop = Long.valueOf(components[2]);
+            TestState state = TestState.valueOf(components[1]);
+            state.start = Long.valueOf(components[2]);
+            state.stop = Long.valueOf(components[3]);
             return state;
         } catch (NumberFormatException e) {
             LOGGER.info("Couldn't parse test state CSV: " + line, e);
@@ -118,6 +119,6 @@ public enum TestState {
 
     @Override
     public String toString() {
-        return name() + "," + start + "," + stop;
+        return String.format("%s,%s,%s,%s\n", System.currentTimeMillis(), name(), start, stop);
     }
 }

--- a/explorer/service/src/main/java/org/radixdlt/explorer/system/TestStateProvider.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/system/TestStateProvider.java
@@ -6,8 +6,6 @@ import io.reactivex.subjects.PublishSubject;
 import org.radixdlt.explorer.helper.DumpHelper;
 import org.radixdlt.explorer.nodes.model.NodeInfo;
 import org.radixdlt.explorer.system.model.SystemInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.Collection;
@@ -21,8 +19,6 @@ import static org.radixdlt.explorer.system.TestState.TERMINATED;
  * Enables means of getting information on the current test state.
  */
 class TestStateProvider {
-    private static final Logger LOGGER = LoggerFactory.getLogger("org.radixdlt.explorer");
-
     private final PublishSubject<TestState> subject;
     private final CompositeDisposable disposables;
     private final Map<String, SystemInfo> systemInfo;
@@ -117,6 +113,7 @@ class TestStateProvider {
             isStarted = false;
             disposables.clear();
             subject.onComplete();
+            dumpHelper.stopDumpExecutor();
         }
     }
 

--- a/explorer/service/src/test/java/org/radixdlt/explorer/helper/DumpHelperTest.java
+++ b/explorer/service/src/test/java/org/radixdlt/explorer/helper/DumpHelperTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,6 +32,20 @@ public class DumpHelperTest {
     }
 
     @Test
+    public void when_clearing_data_before_dump__previous_data_is_removed_from_file() throws IOException {
+        DumpHelper dumpHelper = new DumpHelper(PATH);
+        dumpHelper.dumpData("first");
+        dumpHelper.dumpData("second");
+        dumpHelper.dumpData("third", true);
+        dumpHelper.dumpData("fourth").blockingAwait();
+
+        List<String> lines = Files.readAllLines(PATH);
+        assertThat(lines.size()).isEqualTo(2);
+        assertThat(lines.get(0)).isEqualTo("third");
+        assertThat(lines.get(1)).isEqualTo("fourth");
+    }
+
+    @Test
     public void when_restoring_dumped_data__the_last_line_is_returned() {
         DumpHelper dumpHelper = new DumpHelper(PATH);
         dumpHelper.dumpData("1");
@@ -39,4 +54,32 @@ public class DumpHelperTest {
         String data = dumpHelper.restoreData().blockingGet();
         assertThat(data).isEqualTo("2");
     }
+
+    @Test
+    public void when_submitting_tasks__the_submit_order_is_honored() throws IOException {
+        DumpHelper dumpHelper = new DumpHelper(PATH);
+        dumpHelper.dumpData("zero");
+        dumpHelper.dumpData("eins");
+        String snapshot = dumpHelper.restoreData().blockingGet();
+        dumpHelper.dumpData("zwei");
+        dumpHelper.dumpData("drei").blockingAwait();
+
+        List<String> lines = Files.readAllLines(PATH);
+        assertThat(lines.size()).isEqualTo(4);
+        assertThat(lines.get(0)).isEqualTo("zero");
+        assertThat(lines.get(1)).isEqualTo("eins");
+        assertThat(lines.get(2)).isEqualTo("zwei");
+        assertThat(lines.get(3)).isEqualTo("drei");
+
+        assertThat(snapshot).isEqualTo("eins");
+    }
+
+    @Test
+    public void after_dump_helper_is_stopped__no_more_tasks_can_be_submitted() {
+        DumpHelper dumpHelper = new DumpHelper(PATH);
+        dumpHelper.stop().blockingAwait();
+        Throwable error = dumpHelper.dumpData("ett").blockingGet();
+        assertThat(error).isInstanceOf(RejectedExecutionException.class);
+    }
+
 }

--- a/explorer/service/src/test/java/org/radixdlt/explorer/helper/DumpHelperTest.java
+++ b/explorer/service/src/test/java/org/radixdlt/explorer/helper/DumpHelperTest.java
@@ -1,0 +1,45 @@
+package org.radixdlt.explorer.helper;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DumpHelperTest {
+    private static final Path PATH = Paths.get("dump_helper_test.txt");
+
+
+    @After
+    public void afterTest() throws IOException {
+        Files.deleteIfExists(PATH);
+    }
+
+
+    @Test
+    public void when_dumping_data_to_file__it_is_appended_to_the_end() throws Exception {
+        DumpHelper dumpHelper = new DumpHelper();
+        dumpHelper.dumpData("first\n".getBytes(), PATH);
+        dumpHelper.dumpData("second\n".getBytes(), PATH).get();
+
+        List<String> lines = Files.readAllLines(PATH);
+        assertThat(lines.size()).isEqualTo(2);
+        assertThat(lines.get(0)).isEqualTo("first");
+        assertThat(lines.get(1)).isEqualTo("second");
+    }
+
+    @Test
+    public void when_restoring_dumped_data__the_last_line_is_returned() throws Exception {
+        DumpHelper dumpHelper = new DumpHelper();
+        dumpHelper.dumpData("first\n".getBytes(), PATH).get();
+        dumpHelper.dumpData("second\n".getBytes(), PATH).get();
+
+        String data = dumpHelper.restoreLastDumpedData(PATH);
+        assertThat(data).isEqualTo("second");
+    }
+}

--- a/explorer/service/src/test/java/org/radixdlt/explorer/helper/DumpHelperTest.java
+++ b/explorer/service/src/test/java/org/radixdlt/explorer/helper/DumpHelperTest.java
@@ -14,7 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DumpHelperTest {
     private static final Path PATH = Paths.get("dump_helper_test.txt");
 
-
     @After
     public void afterTest() throws IOException {
         Files.deleteIfExists(PATH);
@@ -22,24 +21,22 @@ public class DumpHelperTest {
 
 
     @Test
-    public void when_dumping_data_to_file__it_is_appended_to_the_end() throws Exception {
-        DumpHelper dumpHelper = new DumpHelper();
-        dumpHelper.dumpData("first\n".getBytes(), PATH);
-        dumpHelper.dumpData("second\n".getBytes(), PATH).get();
+    public void when_dumping_data_to_file__it_is_appended_to_the_end() throws IOException {
+        DumpHelper dumpHelper = new DumpHelper(PATH);
+        dumpHelper.dumpData("first");
+        dumpHelper.dumpData("second").blockingAwait();
 
         List<String> lines = Files.readAllLines(PATH);
-        assertThat(lines.size()).isEqualTo(2);
-        assertThat(lines.get(0)).isEqualTo("first");
-        assertThat(lines.get(1)).isEqualTo("second");
+        assertThat(lines.get(lines.size() - 1)).isEqualTo("second");
     }
 
     @Test
-    public void when_restoring_dumped_data__the_last_line_is_returned() throws Exception {
-        DumpHelper dumpHelper = new DumpHelper();
-        dumpHelper.dumpData("first\n".getBytes(), PATH).get();
-        dumpHelper.dumpData("second\n".getBytes(), PATH).get();
+    public void when_restoring_dumped_data__the_last_line_is_returned() {
+        DumpHelper dumpHelper = new DumpHelper(PATH);
+        dumpHelper.dumpData("1");
+        dumpHelper.dumpData("2");
 
-        String data = dumpHelper.restoreLastDumpedData(PATH);
-        assertThat(data).isEqualTo("second");
+        String data = dumpHelper.restoreData().blockingGet();
+        assertThat(data).isEqualTo("2");
     }
 }

--- a/explorer/service/src/test/java/org/radixdlt/explorer/system/TestStateProviderTest.java
+++ b/explorer/service/src/test/java/org/radixdlt/explorer/system/TestStateProviderTest.java
@@ -2,6 +2,7 @@ package org.radixdlt.explorer.system;
 
 import io.reactivex.subjects.PublishSubject;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.radixdlt.explorer.nodes.model.NodeInfo;
 import org.radixdlt.explorer.system.model.SystemInfo;
@@ -28,6 +29,11 @@ import static org.radixdlt.explorer.system.TestState.TERMINATED;
 public class TestStateProviderTest {
     private static final Path TEST_DUMP_FILE_PATH = Paths.get("test_state_provider_test.csv").toAbsolutePath();
 
+    @Before
+    public void beforeTest() throws Exception {
+        Files.deleteIfExists(TEST_DUMP_FILE_PATH);
+    }
+
     @After
     public void afterTest() throws Exception {
         Files.deleteIfExists(TEST_DUMP_FILE_PATH);
@@ -36,7 +42,7 @@ public class TestStateProviderTest {
 
     @Test
     public void when_starting_metrics_provider__previous_metrics_value_is_restored() throws IOException {
-        String line = TERMINATED.name() + ",0,1";
+        String line = "0," + TERMINATED.name() + ",0,1";
         byte[] data = line.getBytes(UTF_8);
         Files.write(TEST_DUMP_FILE_PATH, data, CREATE, WRITE);
 
@@ -52,7 +58,7 @@ public class TestStateProviderTest {
     @Test
     public void when_node_count_drops_below_threshold__finished_state_is_reported_back() throws IOException {
         // Define a known initial state
-        String line = TERMINATED.name() + ",0,0";
+        String line = "0," + TERMINATED.name() + ",0,0";
         byte[] data = line.getBytes(UTF_8);
         Files.write(TEST_DUMP_FILE_PATH, data, CREATE, WRITE);
 
@@ -76,7 +82,7 @@ public class TestStateProviderTest {
     @Test
     public void when_node_count_stays_above_threshold__state_is_not_changed() throws IOException {
         // Define a known initial state
-        String line = TERMINATED.name() + ",0,0";
+        String line = "0," + TERMINATED.name() + ",0,0";
         byte[] data = line.getBytes(UTF_8);
         Files.write(TEST_DUMP_FILE_PATH, data, CREATE, WRITE);
 


### PR DESCRIPTION
There is an issue with synching dumped data to file system which
sometimes corrupts our persisted test state. This change aims to
mitigate that issue.