### PR TITLE
Track nodes drop off for test state

### DIFF
--- a/explorer/service/src/main/java/org/radixdlt/explorer/Application.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/Application.java
@@ -194,8 +194,9 @@ public class Application {
     private static TestStateService buildTestStateService() {
         Configuration configuration = Configuration.getInstance();
         int runningThreshold = configuration.getTestRunningThreshold();
+        float nodesDeclineFraction = configuration.getNodesDeclineFraction();
         Path stateDumpPath = configuration.getTestStateDumpFilePath();
-        return new TestStateService(runningThreshold, stateDumpPath);
+        return new TestStateService(runningThreshold, nodesDeclineFraction, stateDumpPath);
     }
 
     /**

--- a/explorer/service/src/main/java/org/radixdlt/explorer/config/Configuration.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/config/Configuration.java
@@ -25,6 +25,7 @@ public final class Configuration {
     public static final long DEFAULT_METRICS_TOTAL = 100;
     public static final long DEFAULT_NODES_INTERVAL = SECONDS.toMillis(30);
     public static final float DEFAULT_NODES_FRACTION = 0.1f;
+    public static final float DEFAULT_NODES_DECLINE_FRACTION = 0.1f;
     public static final int DEFAULT_NODES_MAX_COUNT = 20;
     public static final long DEFAULT_UNIVERSE_SHARD_COUNT = 1L;
     public static final int DEFAULT_TEST_RUNNING = 100;
@@ -130,6 +131,20 @@ public final class Configuration {
         }
 
         return password;
+    }
+
+    /**
+     * @return Returns the fraction of dropped nodes to consider as a
+     * signal to transition to FINISHED state.
+     */
+    public synchronized float getNodesDeclineFraction() {
+        String value = properties.getProperty("nodes.decline");
+        try {
+            return Float.parseFloat(value);
+        } catch (NullPointerException | NumberFormatException e) {
+            LOGGER.warn("Couldn't read nodes decline fraction, falling back to default", e);
+            return DEFAULT_NODES_DECLINE_FRACTION;
+        }
     }
 
     /**

--- a/explorer/service/src/main/java/org/radixdlt/explorer/config/Configuration.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/config/Configuration.java
@@ -40,7 +40,7 @@ public final class Configuration {
      */
     private Configuration() {
         properties = new Properties();
-        reload();
+        reload(CONFIG_FILE);
     }
 
     /**
@@ -55,8 +55,8 @@ public final class Configuration {
      * not be called by application logic. It's intended for testing
      * purposes only.
      */
-    synchronized void reload() {
-        try (InputStream source = new FileInputStream(CONFIG_FILE)) {
+    synchronized void reload(String configFilePath) {
+        try (InputStream source = new FileInputStream(configFilePath)) {
             properties.clear();
             properties.load(source);
         } catch (IOException e) {

--- a/explorer/service/src/main/java/org/radixdlt/explorer/system/TestStateProvider.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/system/TestStateProvider.java
@@ -222,9 +222,9 @@ class TestStateProvider {
         // TODO: Piers wants to transition to FINISHED state when >=90% of the data has been
         // validated (storedPerShard). Problem is that systemInfo is not normalised like in
         // MetricsProvide.calculateMetrics.      
-        if (currentState == TestState.STARTED) {
-            return (currentState.getStartTimestamp() + 60 * 60 * 1000) > System.currentTimeMillis();
-        }
+        //if (currentState == TestState.STARTED) {
+        //    return (currentState.getStartTimestamp() + 60 * 60 * 1000) > System.currentTimeMillis();
+        //}
 
         // sum(radixdlt_core_ledger{key="storing_per_shard"})
         // When the cumulative TPS is above the threshold then the test is

--- a/explorer/service/src/main/java/org/radixdlt/explorer/system/TestStateProvider.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/system/TestStateProvider.java
@@ -209,16 +209,6 @@ class TestStateProvider {
             return false;
         }
 
-        // The storingPerShard works well for detecting when test is about to start
-        // but sucks for detecting when test is finished.
-        //
-        // TODO: Piers wants to transition to FINISHED state when >=90% of the data has been
-        // validated (storedPerShard). Problem is that systemInfo is not normalised like in
-        // MetricsProvide.calculateMetrics.      
-        //if (currentState == TestState.STARTED) {
-        //    return (currentState.getStartTimestamp() + 60 * 60 * 1000) > System.currentTimeMillis();
-        //}
-
         // sum(radixdlt_core_ledger{key="storing_per_shard"})
         // When the cumulative TPS is above the threshold then the test is
         // considered running

--- a/explorer/service/src/main/java/org/radixdlt/explorer/system/TestStateProvider.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/system/TestStateProvider.java
@@ -40,7 +40,6 @@ class TestStateProvider {
     private TestState currentState;
     private boolean isStarted;
     private int highNodeCount;
-    private int lowNodeCount;
 
     /**
      * Creates a new instance of this provider.
@@ -66,7 +65,6 @@ class TestStateProvider {
         this.measuringThreshold = measuringTpsThreshold;
         this.maxNodeDeclineFraction = nodeDeclineThreshold;
         this.highNodeCount = Integer.MIN_VALUE;
-        this.lowNodeCount = Integer.MAX_VALUE;
     }
 
     /**
@@ -136,17 +134,12 @@ class TestStateProvider {
                 highNodeCount = size;
             }
 
-            if (size < lowNodeCount) {
-                lowNodeCount = size;
-            }
-
             nodeInfo.clear();
 
             if (size <= 1) {
                 // We've hit rock bottom, reset our
                 // extreme values and bail out.
                 highNodeCount = Integer.MIN_VALUE;
-                lowNodeCount = Integer.MAX_VALUE;
                 return;
             }
 

--- a/explorer/service/src/main/java/org/radixdlt/explorer/system/TestStateService.java
+++ b/explorer/service/src/main/java/org/radixdlt/explorer/system/TestStateService.java
@@ -15,8 +15,8 @@ public class TestStateService implements Service {
     private static final Logger LOGGER = LoggerFactory.getLogger("org.radixdlt.explorer");
     private final TestStateProvider testStateProvider;
 
-    public TestStateService(int runningTpsThreshold, Path stateDumpFile) {
-        testStateProvider = new TestStateProvider(runningTpsThreshold, stateDumpFile);
+    public TestStateService(int runningTpsThreshold, float nodesDeclineFraction, Path stateDumpFile) {
+        testStateProvider = new TestStateProvider(runningTpsThreshold, nodesDeclineFraction, stateDumpFile);
     }
 
     @Override

--- a/explorer/service/src/main/resources/config.properties
+++ b/explorer/service/src/main/resources/config.properties
@@ -2,6 +2,7 @@ nodes.url=http://node_finder:8080/list?format=json
 nodes.interval=30000
 nodes.fraction=0.2
 nodes.max=20
+nodes.decline=0.1
 nodes.username=admin
 nodes.password=p4ssword2
 metrics.interval=4000

--- a/explorer/service/src/test/java/org/radixdlt/explorer/config/ConfigurationTest.java
+++ b/explorer/service/src/test/java/org/radixdlt/explorer/config/ConfigurationTest.java
@@ -43,49 +43,49 @@ public class ConfigurationTest {
     @Test
     public void when_requesting_valid_nodes_url__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "nodes.url=path".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNodesUrl()).isEqualTo("path");
     }
 
     @Test
     public void when_requesting_valid_nodes_refresh_interval__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "nodes.interval=10000".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNodesRefreshInterval()).isEqualTo(10000L);
     }
 
     @Test
     public void when_requesting_valid_subset_fraction__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "nodes.fraction=0.2".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNodesSubsetFraction()).isEqualTo(0.2f);
     }
 
     @Test
     public void when_requesting_valid_subset_max_count__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "nodes.max=2".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getMaxNodesSubsetCount()).isEqualTo(2);
     }
 
     @Test
     public void when_requesting_existing_username__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "nodes.username=dan".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNodesAuthUsername()).isEqualTo("dan");
     }
 
     @Test
     public void when_requesting_existing_password__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "nodes.password=D1tg0d".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNodesAuthPassword()).isEqualTo("D1tg0d");
     }
 
     @Test
     public void when_requesting_valid_calculation_interval__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "metrics.interval=1000".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getMetricsCalculationInterval()).isEqualTo(1000L);
     }
 
@@ -93,56 +93,56 @@ public class ConfigurationTest {
     public void when_requesting_valid_total_transaction_count__correct_value_is_returned() throws IOException {
         // TODO: Figure out how to test environment variable path too
         Files.write(CONFIG, "metrics.max=12".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getMetricsTotalTransactions()).isEqualTo(12L);
     }
 
     @Test
     public void when_requesting_valid_metrics_dump_file__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "metrics.dump=metrics_test.csv".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getMetricsDumpFilePath()).isEqualTo(Paths.get("metrics_test.csv"));
     }
 
     @Test
     public void when_requesting_existing_transactions_page_size__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "transactions.size=100".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getTransactionsPageSize()).isEqualTo(100);
     }
 
     @Test
     public void whe_requesting_existing_latest_transaction_timestamp__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "transactions.latest=123".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getLatestTransactionTimestamp()).isEqualTo(123);
     }
 
     @Test
     public void when_requesting_valid_shards_count__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "universe.shards=2.0E2".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getUniverseShardCount()).isEqualTo(200L);
     }
 
     @Test
     public void when_requesting_existing_universe_magic__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "universe.magic=22".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getUniverseMagic()).isEqualTo(22);
     }
 
     @Test
     public void when_requesting_valid_test_state_dump_file__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "test.dump=state_test.csv".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getTestStateDumpFilePath()).isEqualTo(Paths.get("state_test.csv"));
     }
 
     @Test
     public void when_requesting_existing_test_measuring_threshold__correct_value_is_returned() throws IOException {
         Files.write(CONFIG, "test.running=4".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getTestRunningThreshold()).isEqualTo(4);
     }
 
@@ -151,7 +151,7 @@ public class ConfigurationTest {
         long nextTestTimestamp = System.currentTimeMillis() + 10_000;
         Files.write(TESTS, Long.toString(nextTestTimestamp).getBytes());
         Files.write(CONFIG, ("test.next=" + TESTS.toString()).getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNextTestRunUtc()).isEqualTo(nextTestTimestamp);
     }
 
@@ -160,7 +160,7 @@ public class ConfigurationTest {
         long nextTestTimestamp = System.currentTimeMillis() + 10_000;
         Files.write(TESTS, Long.toString(nextTestTimestamp).getBytes());
         Files.write(CONFIG, ("test.next=" + TESTS.toString()).getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNextTestRunUtc()).isEqualTo(nextTestTimestamp);
 
         long nextNextTestTimestamp = System.currentTimeMillis() + 20_000;
@@ -173,154 +173,154 @@ public class ConfigurationTest {
     @Test
     public void when_requesting_invalid_nodes_refresh_interval__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "nodes.interval=invalid".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNodesRefreshInterval()).isEqualTo(DEFAULT_NODES_INTERVAL);
     }
 
     @Test
     public void when_requesting_invalid_subset_fraction__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "nodes.fraction=invalid".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNodesSubsetFraction()).isEqualTo(DEFAULT_NODES_FRACTION);
     }
 
     @Test
     public void when_requesting_invalid_subset_max_count__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "nodes.max=invalid".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getMaxNodesSubsetCount()).isEqualTo(DEFAULT_NODES_MAX_COUNT);
     }
 
     @Test
     public void when_requesting_invalid_calculation_interval__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "metrics.interval=invalid".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getMetricsCalculationInterval()).isEqualTo(DEFAULT_METRICS_INTERVAL);
     }
 
     @Test
     public void when_requesting_invalid_total_transactions_count__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "metrics.max=invalid".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getMetricsTotalTransactions()).isEqualTo(DEFAULT_METRICS_TOTAL);
     }
 
     @Test
     public void when_requesting_invalid_transactions_page_size__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "transactions.size=invalid".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getTransactionsPageSize()).isEqualTo(DEFAULT_TRANSACTIONS_PAGE_SIZE);
     }
 
     @Test
     public void when_requesting_invalid_latest_transaction_timestamp__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "transactions.latest=invalid".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getLatestTransactionTimestamp()).isEqualTo(DEFAULT_LATEST_TRANSACTION_TIMESTAMP);
     }
 
     @Test
     public void when_requesting_invalid_shards_count__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "universe.shards=invalid".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getUniverseShardCount()).isEqualTo(DEFAULT_UNIVERSE_SHARD_COUNT);
     }
 
     @Test
     public void when_requesting_invalid_universe_magic__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "universe.magic=invalid".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getUniverseMagic()).isEqualTo(DEFAULT_UNIVERSE_MAGIC);
     }
 
     @Test
     public void when_requesting_invalid_test_measuring_threshold__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "test.running=invalid".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getTestRunningThreshold()).isEqualTo(DEFAULT_TEST_RUNNING);
     }
 
     @Test
     public void when_requesting_invalid_next_test_timestamp__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "test.next=invalid".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNextTestRunUtc()).isEqualTo(DEFAULT_NEXT_TEST);
     }
 
     @Test
     public void when_requesting_non_existing_nodes_url__null_is_returned() throws IOException {
         Files.write(CONFIG, "".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNodesUrl()).isNull();
     }
 
     @Test
     public void when_requesting_non_existing_nodes_refresh_interval__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNodesRefreshInterval()).isEqualTo(DEFAULT_NODES_INTERVAL);
     }
 
     @Test
     public void when_requesting_non_existing_subset_fraction__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNodesSubsetFraction()).isEqualTo(DEFAULT_NODES_FRACTION);
     }
 
     @Test
     public void when_requesting_non_existing_subset_max_count__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getMaxNodesSubsetCount()).isEqualTo(DEFAULT_NODES_MAX_COUNT);
     }
 
     @Test
     public void when_requesting_non_existing_calculation_interval__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getMetricsCalculationInterval()).isEqualTo(DEFAULT_METRICS_INTERVAL);
     }
 
     @Test
     public void when_requesting_non_existing_total_transactions_count__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getMetricsTotalTransactions()).isEqualTo(DEFAULT_METRICS_TOTAL);
     }
 
     @Test
     public void when_requesting_non_existing_transactions_page_size__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getTransactionsPageSize()).isEqualTo(DEFAULT_TRANSACTIONS_PAGE_SIZE);
     }
 
     @Test
     public void when_requesting_non_existing_latest_transaction_timestamp__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getLatestTransactionTimestamp()).isEqualTo(DEFAULT_LATEST_TRANSACTION_TIMESTAMP);
     }
 
     @Test
     public void when_requesting_non_existing_shards_count__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getUniverseShardCount()).isEqualTo(DEFAULT_UNIVERSE_SHARD_COUNT);
     }
 
     @Test
     public void when_requesting_non_existing_universe_magic__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getUniverseMagic()).isEqualTo(DEFAULT_UNIVERSE_MAGIC);
     }
 
     @Test
     public void when_requesting_non_existing_next_test_timestamp__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "".getBytes());
-        Configuration.getInstance().reload();
+        Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getNextTestRunUtc()).isEqualTo(DEFAULT_NEXT_TEST);
     }
     // END: Unhappy path
@@ -328,7 +328,9 @@ public class ConfigurationTest {
     // BEGIN: Extreme
     @Test
     public void when_properties_file_does_not_exist__no_exception_is_thrown() {
-        assertThatCode(() -> Configuration.getInstance().reload()).doesNotThrowAnyException();
+        assertThatCode(() -> Configuration.getInstance()
+                .reload(CONFIG.toString()))
+                .doesNotThrowAnyException();
     }
     // END: Extreme
 

--- a/explorer/service/src/test/java/org/radixdlt/explorer/config/ConfigurationTest.java
+++ b/explorer/service/src/test/java/org/radixdlt/explorer/config/ConfigurationTest.java
@@ -15,6 +15,7 @@ import static org.radixdlt.explorer.config.Configuration.DEFAULT_LATEST_TRANSACT
 import static org.radixdlt.explorer.config.Configuration.DEFAULT_METRICS_INTERVAL;
 import static org.radixdlt.explorer.config.Configuration.DEFAULT_METRICS_TOTAL;
 import static org.radixdlt.explorer.config.Configuration.DEFAULT_NEXT_TEST;
+import static org.radixdlt.explorer.config.Configuration.DEFAULT_NODES_DECLINE_FRACTION;
 import static org.radixdlt.explorer.config.Configuration.DEFAULT_NODES_FRACTION;
 import static org.radixdlt.explorer.config.Configuration.DEFAULT_NODES_INTERVAL;
 import static org.radixdlt.explorer.config.Configuration.DEFAULT_NODES_MAX_COUNT;
@@ -66,6 +67,13 @@ public class ConfigurationTest {
         Files.write(CONFIG, "nodes.max=2".getBytes());
         Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getMaxNodesSubsetCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void when_requesting_valid_decline_fraction__correct_value_is_returned() throws IOException {
+        Files.write(CONFIG, "nodes.decline=1.0".getBytes());
+        Configuration.getInstance().reload(CONFIG.toString());
+        assertThat(Configuration.getInstance().getNodesDeclineFraction()).isEqualTo(1f);
     }
 
     @Test
@@ -192,6 +200,13 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void when_requesting_invalid_decline_fraction__default_value_is_returned() throws IOException {
+        Files.write(CONFIG, "nodes.decline=invalid".getBytes());
+        Configuration.getInstance().reload(CONFIG.toString());
+        assertThat(Configuration.getInstance().getNodesDeclineFraction()).isEqualTo(DEFAULT_NODES_DECLINE_FRACTION);
+    }
+
+    @Test
     public void when_requesting_invalid_calculation_interval__default_value_is_returned() throws IOException {
         Files.write(CONFIG, "metrics.interval=invalid".getBytes());
         Configuration.getInstance().reload(CONFIG.toString());
@@ -273,6 +288,13 @@ public class ConfigurationTest {
         Files.write(CONFIG, "".getBytes());
         Configuration.getInstance().reload(CONFIG.toString());
         assertThat(Configuration.getInstance().getMaxNodesSubsetCount()).isEqualTo(DEFAULT_NODES_MAX_COUNT);
+    }
+
+    @Test
+    public void when_requesting_non_existing_decline_fraction__default_value_is_returned() throws IOException {
+        Files.write(CONFIG, "".getBytes());
+        Configuration.getInstance().reload(CONFIG.toString());
+        assertThat(Configuration.getInstance().getNodesDeclineFraction()).isEqualTo(DEFAULT_NODES_DECLINE_FRACTION);
     }
 
     @Test

--- a/explorer/service/src/test/java/org/radixdlt/explorer/system/TestStateProviderTest.java
+++ b/explorer/service/src/test/java/org/radixdlt/explorer/system/TestStateProviderTest.java
@@ -1,35 +1,46 @@
 package org.radixdlt.explorer.system;
 
 import io.reactivex.subjects.PublishSubject;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Test;
+import org.radixdlt.explorer.nodes.model.NodeInfo;
+import org.radixdlt.explorer.system.model.SystemInfo;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.WRITE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.radixdlt.explorer.system.TestState.FINISHED;
+import static org.radixdlt.explorer.system.TestState.STARTED;
 import static org.radixdlt.explorer.system.TestState.TERMINATED;
 
 public class TestStateProviderTest {
     private static final Path TEST_DUMP_FILE_PATH = Paths.get("test_state_provider_test.csv").toAbsolutePath();
 
-    @AfterClass
-    public static void afterSuite() throws Exception {
+    @After
+    public void afterTest() throws Exception {
         Files.deleteIfExists(TEST_DUMP_FILE_PATH);
     }
 
 
     @Test
-    public void when_starting_metrics_provider__previous_metrics_value_is_restored() throws Exception {
+    public void when_starting_metrics_provider__previous_metrics_value_is_restored() throws IOException {
         String line = TERMINATED.name() + ",0,1";
         byte[] data = line.getBytes(UTF_8);
         Files.write(TEST_DUMP_FILE_PATH, data, CREATE, WRITE);
 
-        TestStateProvider testStateProvider = new TestStateProvider(1000, TEST_DUMP_FILE_PATH);
+        TestStateProvider testStateProvider = new TestStateProvider(1000, 0.1f, TEST_DUMP_FILE_PATH);
         testStateProvider.start(PublishSubject.create(), PublishSubject.create());
         TestState testState = testStateProvider.getState();
 
@@ -38,4 +49,70 @@ public class TestStateProviderTest {
         assertThat(testState.getStopTimestamp()).isEqualTo(1);
     }
 
+    @Test
+    public void when_node_count_drops_below_threshold__finished_state_is_reported_back() throws IOException {
+        // Define a known initial state
+        String line = TERMINATED.name() + ",0,0";
+        byte[] data = line.getBytes(UTF_8);
+        Files.write(TEST_DUMP_FILE_PATH, data, CREATE, WRITE);
+
+        // Start the test state provider and verify the initial state
+        PublishSubject<Collection<NodeInfo>> nodes = PublishSubject.create();
+        PublishSubject<Map<String, SystemInfo>> system = PublishSubject.create();
+        TestStateProvider testStateProvider = new TestStateProvider(1000, 0.2f, TEST_DUMP_FILE_PATH);
+        testStateProvider.start(nodes, system);
+        assertThat(testStateProvider.getState()).isEqualTo(TERMINATED);
+
+        // Set and verify the starting point state for this test
+        nodes.onNext(getMockedTestNodes(10));
+        system.onNext(getMockedSystemInfo(2, 1000));
+        assertThat(testStateProvider.getState()).isEqualTo(STARTED);
+
+        // Change the test and verify the expected state
+        nodes.onNext(getMockedTestNodes(8));
+        assertThat(testStateProvider.getState()).isEqualTo(FINISHED);
+    }
+
+    @Test
+    public void when_node_count_stays_above_threshold__state_is_not_changed() throws IOException {
+        // Define a known initial state
+        String line = TERMINATED.name() + ",0,0";
+        byte[] data = line.getBytes(UTF_8);
+        Files.write(TEST_DUMP_FILE_PATH, data, CREATE, WRITE);
+
+        // Start the test state provider and verify the internal state
+        PublishSubject<Collection<NodeInfo>> nodes = PublishSubject.create();
+        PublishSubject<Map<String, SystemInfo>> system = PublishSubject.create();
+        TestStateProvider testStateProvider = new TestStateProvider(1000, 0.2f, TEST_DUMP_FILE_PATH);
+        testStateProvider.start(nodes, system);
+        assertThat(testStateProvider.getState()).isEqualTo(TERMINATED);
+
+        // Set and verify the starting point state for this test
+        nodes.onNext(getMockedTestNodes(10));
+        system.onNext(getMockedSystemInfo(2, 1000));
+        assertThat(testStateProvider.getState()).isEqualTo(STARTED);
+
+        // Change the test and verify the expected state
+        nodes.onNext(getMockedTestNodes(9));
+        assertThat(testStateProvider.getState()).isEqualTo(STARTED);
+    }
+
+
+    private Collection<NodeInfo> getMockedTestNodes(int count) {
+        Collection<NodeInfo> result = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            result.add(mock(NodeInfo.class));
+        }
+        return result;
+    }
+
+    private Map<String, SystemInfo> getMockedSystemInfo(int count, long storingPerShard) {
+        Map<String, SystemInfo> result = new HashMap<>();
+        for (int i = 0; i < count; i++) {
+            SystemInfo mockedSystemInfo = mock(SystemInfo.class);
+            when(mockedSystemInfo.getStoringPerShard()).thenReturn(storingPerShard);
+            result.put(Integer.toString(i), mockedSystemInfo);
+        }
+        return result;
+    }
 }


### PR DESCRIPTION
There is now a configuration property that controls how many nodes are allowed to "drop off" compared to the peak count. If more nodes are dropped off than what is considered acceptable, the
`TestStateProvider` reserves the right to consider the test eligible for a state transition.

Fixes: #70